### PR TITLE
fix mvn build error:'错误: 编码GBK的不可映射字符'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,6 +140,7 @@
                     <target>1.6</target>
                     <compilerArgument>-g</compilerArgument>
                     <verbose>true</verbose>
+					<encoding>UTF-8</encoding>
                 </configuration>
 
             </plugin>


### PR DESCRIPTION
build under jdk1.8, still target 1.6