### PR TITLE
添加类似swagger的接口描述信息

### DIFF
--- a/serviceframework-web/pom.xml
+++ b/serviceframework-web/pom.xml
@@ -56,6 +56,22 @@
             <version>${parent.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.json4s</groupId>
+            <artifactId>json4s-jackson_2.11</artifactId>
+            <version>3.6.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.json4s</groupId>
+            <artifactId>json4s-ext_2.11</artifactId>
+            <version>3.2.11</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-reflect</artifactId>
+            <version>${scala.version}</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/serviceframework-web/src/main/java/com/example/controller/http/TagController.java
+++ b/serviceframework-web/src/main/java/com/example/controller/http/TagController.java
@@ -1,7 +1,7 @@
 package com.example.controller.http;
 
 import com.example.model.Tag;
-import net.csdn.annotation.rest.At;
+import net.csdn.annotation.rest.*;
 import net.csdn.modules.http.ApplicationController;
 import net.csdn.modules.http.RestRequest;
 import net.csdn.modules.http.ViewType;
@@ -9,9 +9,31 @@ import net.csdn.modules.http.ViewType;
 /**
  * 12/25/13 WilliamZhu(allwefantasy@gmail.com)
  */
+@OpenAPIDefinition(
+        info = @BasicInfo(desc = "标签管理接口集合",
+                contact = @Contact(url = "", name = "allwefantasy", email = "allwefantasy@gmail.com"),
+                license = @License(name = "Apache", url = "...")
+        ), externalDocs = @ExternalDocumentation(description = ""), servers = {
+        @Server(url = "http://127.0.0.1", description = "测试服务器")
+}
+)
 public class TagController extends ApplicationController {
 
     @At(path = "/tag", types = {RestRequest.Method.POST})
+    @Parameters(
+            @Parameter(name = "name", required = true, description = "标签的名字")
+    )
+    @Responses(
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "返回值为json",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(type = "string", format = "json", description = "")
+
+                    )
+            )
+    )
     public void save() {
         Tag tag = Tag.create(params());
         if (tag.save()) {

--- a/serviceframework-web/src/main/java/net/csdn/ScalaMethodMacros.scala
+++ b/serviceframework-web/src/main/java/net/csdn/ScalaMethodMacros.scala
@@ -1,0 +1,28 @@
+package net.csdn
+
+import scala.annotation.tailrec
+import scala.language.experimental.macros
+import scala.reflect.macros.blackbox
+
+object ScalaMethodMacros {
+  def nameOfImpl(c: blackbox.Context)(x: c.Tree): c.Tree = {
+    import c.universe._
+
+    @tailrec def extract(x: c.Tree): String = x match {
+      case Ident(TermName(s)) => s
+      case Select(_, TermName(s)) => s
+      case Function(_, body) => extract(body)
+      case Block(_, expr) => extract(expr)
+      case Apply(func, _) => extract(func)
+    }
+
+    val name = extract(x)
+    q"$name"
+  }
+
+  def nameOfMemberImpl(c: blackbox.Context)(f: c.Tree): c.Tree = nameOfImpl(c)(f)
+
+  def str(x: Any): String = macro nameOfImpl
+
+  def str[T](f: T => Any): String = macro nameOfMemberImpl
+}

--- a/serviceframework-web/src/main/java/net/csdn/annotation/rest/Action.java
+++ b/serviceframework-web/src/main/java/net/csdn/annotation/rest/Action.java
@@ -1,0 +1,14 @@
+package net.csdn.annotation.rest;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Action {
+    String summary();
+    String description();
+
+}

--- a/serviceframework-web/src/main/java/net/csdn/annotation/rest/ApiResponse.java
+++ b/serviceframework-web/src/main/java/net/csdn/annotation/rest/ApiResponse.java
@@ -1,0 +1,16 @@
+package net.csdn.annotation.rest;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface ApiResponse {
+    String responseCode();
+
+    String description() default "";
+
+    Content content();
+}

--- a/serviceframework-web/src/main/java/net/csdn/annotation/rest/BasicInfo.java
+++ b/serviceframework-web/src/main/java/net/csdn/annotation/rest/BasicInfo.java
@@ -11,23 +11,23 @@ import java.lang.annotation.Target;
  * Time: 下午4:15
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.METHOD)
+@Target(ElementType.TYPE)
 public @interface BasicInfo {
 
     //描述
     String desc();
 
     //url类型参数
-    String testParams();
+    String testParams() default "";
 
     //支持正则
-    String testResult();
+    String testResult() default "";
 
     //参考State
-    State state();
+    State state() default State.production;
 
-    String author();
+    Contact contact();
 
-    String email();
+    License license();
 }
 

--- a/serviceframework-web/src/main/java/net/csdn/annotation/rest/Contact.java
+++ b/serviceframework-web/src/main/java/net/csdn/annotation/rest/Contact.java
@@ -1,0 +1,15 @@
+package net.csdn.annotation.rest;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface Contact {
+    String url();
+    String name();
+    String email();
+
+}

--- a/serviceframework-web/src/main/java/net/csdn/annotation/rest/Content.java
+++ b/serviceframework-web/src/main/java/net/csdn/annotation/rest/Content.java
@@ -1,0 +1,15 @@
+package net.csdn.annotation.rest;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface Content {
+    String mediaType();
+
+    Schema schema();
+
+}

--- a/serviceframework-web/src/main/java/net/csdn/annotation/rest/EmptySchema.java
+++ b/serviceframework-web/src/main/java/net/csdn/annotation/rest/EmptySchema.java
@@ -1,0 +1,4 @@
+package net.csdn.annotation.rest;
+
+public class EmptySchema {
+}

--- a/serviceframework-web/src/main/java/net/csdn/annotation/rest/ExternalDocumentation.java
+++ b/serviceframework-web/src/main/java/net/csdn/annotation/rest/ExternalDocumentation.java
@@ -1,0 +1,12 @@
+package net.csdn.annotation.rest;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface ExternalDocumentation {
+    String description();
+}

--- a/serviceframework-web/src/main/java/net/csdn/annotation/rest/License.java
+++ b/serviceframework-web/src/main/java/net/csdn/annotation/rest/License.java
@@ -1,0 +1,14 @@
+package net.csdn.annotation.rest;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface License {
+    String name();
+
+    String url();
+}

--- a/serviceframework-web/src/main/java/net/csdn/annotation/rest/OpenAPIDefinition.java
+++ b/serviceframework-web/src/main/java/net/csdn/annotation/rest/OpenAPIDefinition.java
@@ -1,0 +1,17 @@
+package net.csdn.annotation.rest;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface OpenAPIDefinition {
+    BasicInfo info();
+
+    ExternalDocumentation externalDocs();
+
+    Server[] servers();
+
+}

--- a/serviceframework-web/src/main/java/net/csdn/annotation/rest/Parameter.java
+++ b/serviceframework-web/src/main/java/net/csdn/annotation/rest/Parameter.java
@@ -1,0 +1,21 @@
+package net.csdn.annotation.rest;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Parameter {
+    String name();
+
+    boolean required() default false;
+
+    String description() default "";
+
+    boolean allowEmptyValue() default true;
+
+    boolean allowReserved() default false;
+
+}

--- a/serviceframework-web/src/main/java/net/csdn/annotation/rest/Parameters.java
+++ b/serviceframework-web/src/main/java/net/csdn/annotation/rest/Parameters.java
@@ -1,0 +1,13 @@
+package net.csdn.annotation.rest;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Parameters {
+    Parameter[] value();
+
+}

--- a/serviceframework-web/src/main/java/net/csdn/annotation/rest/Responses.java
+++ b/serviceframework-web/src/main/java/net/csdn/annotation/rest/Responses.java
@@ -1,0 +1,12 @@
+package net.csdn.annotation.rest;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Responses {
+    ApiResponse[] value();
+}

--- a/serviceframework-web/src/main/java/net/csdn/annotation/rest/Schema.java
+++ b/serviceframework-web/src/main/java/net/csdn/annotation/rest/Schema.java
@@ -1,0 +1,18 @@
+package net.csdn.annotation.rest;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface Schema {
+    String type();
+
+    String format();
+
+    String description();
+
+    Class implementation() default EmptySchema.class;
+}

--- a/serviceframework-web/src/main/java/net/csdn/annotation/rest/Server.java
+++ b/serviceframework-web/src/main/java/net/csdn/annotation/rest/Server.java
@@ -1,0 +1,14 @@
+package net.csdn.annotation.rest;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface Server {
+    String description();
+
+    String url();
+}

--- a/serviceframework-web/src/main/java/net/csdn/api/controller/APIDescAC.scala
+++ b/serviceframework-web/src/main/java/net/csdn/api/controller/APIDescAC.scala
@@ -1,0 +1,134 @@
+package net.csdn.api.controller
+
+import java.util.List
+
+import com.alibaba.druid.sql.visitor.functions.Concat
+import com.google.common.reflect.ClassPath
+import net.csdn.ServiceFramwork
+import net.csdn.annotation.rest._
+import net.csdn.common.collections.WowCollections
+import net.csdn.common.settings.Settings
+import org.json4s._
+import org.json4s.jackson.Serialization
+import org.json4s.jackson.Serialization.{read, write}
+import net.csdn.ScalaMethodMacros._
+import org.json4s.JsonDSL._
+
+import scala.collection.JavaConversions._
+import scala.collection.mutable.ArrayBuffer
+
+object APIDescAC {
+  implicit val formats = org.json4s.DefaultFormats +
+    new OpenAPIDefinitionSer()
+
+  def openAPIs(settings: Settings) = {
+
+    var openAPIs = ArrayBuffer[OpenAPI]()
+
+    val controllers = WowCollections.split2(settings.get("application.controller"), ",")
+    controllers.map { c =>
+      val classinfos = ClassPath.from(classOf[ServiceFramwork].getClassLoader).getTopLevelClassesRecursive(c)
+      classinfos.map { ci =>
+        val clzz = Class.forName(ci.getName)
+        clzz.getAnnotations.map { a =>
+          if (a.annotationType() == classOf[OpenAPIDefinition]) {
+            val actions = ArrayBuffer[OpenAction]()
+            clzz.getMethods.filter { m =>
+              m.getAnnotation(classOf[Parameters]) != null
+            }.map { m =>
+
+              actions += OpenAction(m.getName, m.getAnnotation(classOf[Parameters]), m.getAnnotation(classOf[Responses]))
+
+            }
+            openAPIs += OpenAPI(ci.getName, a.asInstanceOf[OpenAPIDefinition], actions)
+          }
+
+        }
+      }
+    }
+    val ser = write(openAPIs)
+    ser
+  }
+}
+
+case class OpenAPI(name: String, o: OpenAPIDefinition, actions: List[OpenAction])
+
+case class OpenAction(name: String, parameters: Parameters, responses: Responses)
+
+class OpenAPIDefinitionSer extends CustomSerializer[OpenAPIDefinition](format => ( {
+  null
+}, {
+  case o: OpenAPIDefinition => {
+
+
+    val info = Extraction.decompose(o.info())(DefaultFormats + new BasicInfoSer())
+    val servers = Extraction.decompose(o.servers())(DefaultFormats + new ServerSer())
+    val externalDocs = Extraction.decompose(o.externalDocs())(DefaultFormats + new ExternalDocumentationSer())
+
+    (str[OpenAPIDefinition](_.info()) -> info) ~
+      (str[OpenAPIDefinition](_.servers()) -> servers) ~
+      (str[OpenAPIDefinition](_.externalDocs()) -> externalDocs)
+  }
+}))
+
+class BasicInfoSer extends CustomSerializer[BasicInfo](format => ( {
+  null
+}, {
+  case o: BasicInfo => {
+    val contact = Extraction.decompose(o.contact())(DefaultFormats + new ContactSer())
+    val license = Extraction.decompose(o.license())(DefaultFormats + new LicenseSer())
+    val state = Extraction.decompose(o.state())(DefaultFormats + new StateSer())
+    (str[BasicInfo](_.desc()) -> JString(o.desc())) ~
+      (str[BasicInfo](_.testParams()) -> JString(o.testParams())) ~
+      (str[BasicInfo](_.testResult()) -> JString(o.testResult())) ~
+      (str[BasicInfo](_.contact()) -> contact) ~
+      (str[BasicInfo](_.license()) -> license) ~
+      (str[BasicInfo](_.state()) -> state)
+
+  }
+}))
+
+class ServerSer extends CustomSerializer[Server](format => ( {
+  null
+}, {
+  case o: Server => {
+    (str[Server](_.description()) -> JString(o.description())) ~
+      (str[Server](_.url()) -> JString(o.url()))
+  }
+}))
+
+class ExternalDocumentationSer extends CustomSerializer[ExternalDocumentation](format => ( {
+  null
+}, {
+  case o: ExternalDocumentation => {
+    (str[ExternalDocumentation](_.description()) -> JString(o.description()))
+  }
+}))
+
+class ContactSer extends CustomSerializer[Contact](format => ( {
+  null
+}, {
+  case o: Contact => {
+    (str[Contact](_.name()) -> JString(o.name())) ~
+      (str[Contact](_.email()) -> JString(o.email())) ~
+      (str[Contact](_.url()) -> JString(o.url()))
+  }
+}))
+
+class LicenseSer extends CustomSerializer[License](format => ( {
+  null
+}, {
+  case o: License => {
+    (str[License](_.name()) -> JString(o.name())) ~
+      (str[License](_.url()) -> JString(o.url()))
+  }
+}))
+
+class StateSer extends CustomSerializer[State](format => ( {
+  null
+}, {
+  case o: State => {
+    (str[State](_.name()) -> JString(o.name()))
+
+  }
+}))

--- a/serviceframework-web/src/main/java/net/csdn/api/controller/APIDescController.java
+++ b/serviceframework-web/src/main/java/net/csdn/api/controller/APIDescController.java
@@ -1,0 +1,14 @@
+package net.csdn.api.controller;
+
+
+import net.csdn.annotation.rest.At;
+import net.csdn.modules.http.ApplicationController;
+import net.csdn.modules.http.RestRequest;
+
+
+public class APIDescController extends ApplicationController {
+    @At(path = "/openapi/ui/spec/", types = {RestRequest.Method.GET, RestRequest.Method.POST})
+    public void ui() {
+        render(200, APIDescAC.openAPIs(settings));
+    }
+}

--- a/serviceframework-web/src/main/java/net/csdn/bootstrap/loader/impl/ControllerLoader.java
+++ b/serviceframework-web/src/main/java/net/csdn/bootstrap/loader/impl/ControllerLoader.java
@@ -66,7 +66,9 @@ public class ControllerLoader implements Loader {
         }
 
         enhancer.enhanceThisClass2(controllers);
-        for (String item : WowCollections.split2(settings.get("application.controller.default", "net.csdn.api.controller.SystemInfoController"), ",")) {
+        for (String item : WowCollections.split2(settings.get("application.controller.default",
+                "net.csdn.api.controller.SystemInfoController,net.csdn.api.controller.APIDescController,"
+        ), ",")) {
             try {
                 moduleList.add(bindAction(Class.forName(item)));
             } catch (Exception e) {


### PR DESCRIPTION
现在你可以这么定义一个接口：

```scala
@OpenAPIDefinition(
        info = @BasicInfo(desc = "标签管理接口集合",
                contact = @Contact(url = "", name = "allwefantasy", email = "allwefantasy@gmail.com"),
                license = @License(name = "Apache", url = "...")
        ), externalDocs = @ExternalDocumentation(description = ""), servers = {
        @Server(url = "http://127.0.0.1", description = "测试服务器")
}
)
public class TagController extends ApplicationController {

    @At(path = "/tag", types = {RestRequest.Method.POST})
    @Parameters(
            @Parameter(name = "name", required = true, description = "标签的名字")
    )
    @Responses(
            @ApiResponse(
                    responseCode = "200",
                    description = "返回值为json",
                    content = @Content(
                            mediaType = "application/json",
                            schema = @Schema(type = "string", format = "json", description = "")

                    )
            )
    )
    public void save() {
        Tag tag = Tag.create(params());
        if (tag.save()) {
            render(200, "成功", ViewType.string);
        }
        render(400, "失败", ViewType.string);
    }
```

然后通过接口 `http://..../openapi/ui/spec/` 可以访问到这些描述信息。