### PR TITLE
Change method name 'detect' to 'isANSIEnabled'

### DIFF
--- a/serviceframework-common/src/main/java/net/csdn/common/jline/ANSI.java
+++ b/serviceframework-common/src/main/java/net/csdn/common/jline/ANSI.java
@@ -41,7 +41,7 @@ public class ANSI {
     /**
      * Tries to detect if the current system supports ANSI.
      */
-    private static boolean detect() {
+    private static boolean isANSIEnabled() {
         if (System.getProperty("jline.enabled", "false").equalsIgnoreCase("false")) {
             return false;
         }
@@ -56,7 +56,7 @@ public class ANSI {
     }
 
     public static boolean isDetected() {
-        return detect();
+        return isANSIEnabled();
     }
 
     private static Boolean enabled;


### PR DESCRIPTION
This class is used to represent ANSI.  This method named 'detect' is to check if ANSI is supported by the current system. Thus, the method name 'isANSIEnabled' is more intuitive than 'detect'.